### PR TITLE
PR-37: Update spec file license to GPL 2.0

### DIFF
--- a/packaging/rpm/rb-aioutliers.spec
+++ b/packaging/rpm/rb-aioutliers.spec
@@ -4,7 +4,7 @@ Release: %{__release}%{?dist}
 BuildArch: noarch
 Summary: RedBorder Python AI Outliers Detection Service
 
-License: AGPL-3.0
+License: GPL-2.0
 URL: https://github.com/redBorder/rb-aioutliers
 Source0: %{name}-%{version}.tar.gz
 


### PR DESCRIPTION
* I updated spec file license from AGPL 3.0 to GPL 2.0