### PR TITLE
PR-61: Fix always anomaly in shallow outliers

### DIFF
--- a/resources/src/ai/shallow_outliers.py
+++ b/resources/src/ai/shallow_outliers.py
@@ -25,33 +25,30 @@ from resources.src.logger import logger
 
 class ShallowOutliers:
     """
-    Shallow AI model for outliers detection. Used whenever there is no deep learning model defined.
-    Input data should be 1-dimensional.
+    Shallow AI model for detecting outliers in 1-dimensional data. Utilized when a deep learning model is not defined.
 
     Args:
-        - sensitivity (float): value between 0 and 1 that makes easier for a point to be considered
-        anomalous. Balances the fact that training and inference data is the same. At 1, there will
-        always be at least 1 anomaly. At 0 there will always be 0 anomalies. Default of 0.95.
-
-        - contamination (float): value between 0 and 1 that represents how many points will it try
-        to consider anomalous during training. Default of 0.01.
+        sensitivity (float, optional): A value between 0 and 1 that adjusts the threshold for identifying anomalies.
+            At 1, at least one anomaly is always identified. At 0, no anomalies are identified. Default is 0.95.
+        
+        contamination (float, optional): A value between 0 and 1 that indicates the proportion of data points
+            to be considered anomalous during training. Default is 0.01.
     """
 
     def __init__(self, sensitivity=0.95, contamination=0.01):
         """
-        Shallow AI model for outliers detection. Used whenever there is no deep learning model defined.
-        Input data should be 1-dimensional.
+        Initializes the ShallowOutliers model.
 
         Args:
-            - sensitivity (float): value between 0 and 1 that makes easier for a point to be considered
-            anomalous. Balances the fact that training and inference data is the same. At 1, there will
-            always be at least 1 anomaly. At 0 there will always be 0 anomalies. Default of 0.95.
+            sensitivity (float, optional): A value between 0 and 1 that adjusts the threshold for identifying anomalies.
+                At 1, at least one anomaly is always identified. At 0, no anomalies are identified. Default is 0.95.
 
-            - contamination (float): value between 0 and 1 that represents how many points will it try
-            to consider anomalous during training. Default of 0.01.
+            contamination (float, optional): A value between 0 and 1 that indicates the proportion of data points
+                to be considered anomalous during training. Default is 0.01.
         """
-        self.sens=sensitivity
-        self.cont=contamination
+        self.sensitivity = sensitivity
+        self.contamination = contamination
+
 
     def predict(self, arr):
         """

--- a/resources/src/ai/shallow_outliers.py
+++ b/resources/src/ai/shallow_outliers.py
@@ -46,8 +46,8 @@ class ShallowOutliers:
             contamination (float, optional): A value between 0 and 1 that indicates the proportion of data points
                 to be considered anomalous during training. Default is 0.01.
         """
-        self.sensitivity = sensitivity
-        self.contamination = contamination
+        self.sens = sensitivity
+        self.cont = contamination
 
 
     def predict(self, arr):
@@ -122,11 +122,11 @@ class ShallowOutliers:
         hour of day and a cosine encoding for the day of the week. This encoding helps the model to
         learn periodic patterns in the data while maintaining simplicity.
         
-        Parameters:
-        timestamps (pd.Series): A Pandas Series of timestamps.
+        Args:
+            timestamps (pd.Series): A Pandas Series of timestamps.
         
         Returns:
-        pd.DataFrame: A DataFrame with sine-cosine encodings for daily and weekly periods.
+            pd.DataFrame: A DataFrame with sine-cosine encodings for daily and weekly periods.
         """
         if not isinstance(timestamp, pd.Series):
             raise ValueError("Input must be a Pandas Series")

--- a/resources/src/config.ini
+++ b/resources/src/config.ini
@@ -17,6 +17,10 @@ backup_path=./backups/
 #target_sensors=FlowSensor
 model_names=traffic
 
+[ShallowOutliers]
+sensitivity=0.95
+contamination=0.01
+
 [Druid]
 druid_endpoint=http://x.x.x.x:8080/druid/v2/
 

--- a/resources/src/server/rest.py
+++ b/resources/src/server/rest.py
@@ -64,6 +64,10 @@ class APIServer:
         self.app = Flask(__name__)
         self.app.add_url_rule('/api/v1/outliers', view_func=self.calculate, methods=['POST'])
         self.exit_code = 0
+        self.shallow = shallow_outliers.ShallowOutliers(
+            sensitivity = config.get("ShallowOutliers", "sensitivity"),
+            contamination = config.get("ShallowOutliers", "contamination")
+        )
         self.ai_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "ai")
         self.deep_models={}
 
@@ -200,7 +204,7 @@ class APIServer:
 
         try:
             if model == 'default':
-                return jsonify(shallow_outliers.ShallowOutliers.execute_prediction_model(data))
+                return jsonify(self.shallow.execute_prediction_model(data))
             if model not in self.deep_models:
                 logger.logger.info(f"Creating instance of model {model}")
                 self.deep_models[model]=outliers.Autoencoder(


### PR DESCRIPTION
* Fixed an issue where there would always be at least 1 anomaly detected, no matter the data, when using the shallow outliers models.
* The config.ini file now also has a section that sets the sensitivity of the  shallow outliers models.